### PR TITLE
Implement server with threads

### DIFF
--- a/echo-server/Cargo.lock
+++ b/echo-server/Cargo.lock
@@ -3,5 +3,236 @@
 version = 3
 
 [[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "bytes"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "echo-server"
 version = "0.1.0"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.132"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
+
+[[package]]
+name = "log"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "memchr"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "mio"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "socket2"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10c98bba371b9b22a71a9414e420f92ddeb2369239af08200816169d5e2dd7aa"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "tokio"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a8325f63a7d4774dd041e363b2409ed1c5cbbd0f867795e661df066b2b0a581"
+dependencies = [
+ "autocfg",
+ "bytes",
+ "libc",
+ "memchr",
+ "mio",
+ "num_cpus",
+ "once_cell",
+ "pin-project-lite",
+ "socket2",
+ "tokio-macros",
+ "winapi",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"

--- a/echo-server/Cargo.toml
+++ b/echo-server/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+tokio = { version = "1.20.1", features = ["rt-multi-thread", "macros", "net", "io-util"] }

--- a/echo-server/README.md
+++ b/echo-server/README.md
@@ -1,0 +1,9 @@
+# Echo server (no threads)
+
+This is a simple implementation of an _echo server_ without threads.
+Here the server listens (via a socket) on some port,
+and sends back whatever content it receives.
+
+We'll start with receiving and sending back text, but we'll want
+to get up to receiving and sending back binary data, i.e., a
+stream of uninterpreted bytes.

--- a/echo-server/src/main.rs
+++ b/echo-server/src/main.rs
@@ -3,6 +3,41 @@
 #![warn(clippy::unwrap_used)]
 #![warn(clippy::expect_used)]
 
-fn main() {
-    println!("Hello, world!");
+use std::{io::{Error, Read, Write}, net::{TcpListener, TcpStream}};
+
+const BUFFER_SIZE: usize = 128;
+
+// Issues to deal with:
+// - Our error handling is fairly weak.
+// - We have no threading, so we only handle one connection at a time.
+// - There should be "proper" logging added to this.
+
+fn main() -> Result<(), Error> {
+    // TODO: Let the user set this port via the command line.
+    let listener = TcpListener::bind("127.0.0.1:60606")?;
+
+    // accept connections and process them serially
+    for stream in listener.incoming() {
+        // TODO: We might want to log or print something here
+        // if we get an Error type in `stream`.
+        // TODO: We also should handle any error coming back from
+        // `echo_stream`.
+        echo_stream(stream?)?;
+    }
+    Ok(())
+}
+
+fn echo_stream(mut stream: TcpStream) -> Result<(), Error> {
+    println!("Handling a stream: {:?}", stream);
+    let mut buf = [0; BUFFER_SIZE];
+    // TODO: Handle the error case here.
+    loop {
+        let num_read_bytes = stream.read(&mut buf)?;
+        if num_read_bytes == 0 {
+            println!("Done handling stream {:?}", stream);
+            return Ok(());
+        }
+        // TODO: Handle the error case here.
+        stream.write_all(&buf[0..num_read_bytes])?;
+    }
 }

--- a/echo-server/src/main.rs
+++ b/echo-server/src/main.rs
@@ -3,41 +3,47 @@
 #![warn(clippy::unwrap_used)]
 #![warn(clippy::expect_used)]
 
-use std::{io::{Error, Read, Write}, net::{TcpListener, TcpStream}};
+use std::io;
+
+use tokio::net::{TcpListener, TcpStream};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 const BUFFER_SIZE: usize = 128;
 
 // Issues to deal with:
 // - Our error handling is fairly weak.
-// - We have no threading, so we only handle one connection at a time.
 // - There should be "proper" logging added to this.
+// - Add something like `clap` to handle command line arguments
+//   - We could specify the port number that way.
 
-fn main() -> Result<(), Error> {
+#[tokio::main]
+async fn main() -> io::Result<()> {
     // TODO: Let the user set this port via the command line.
-    let listener = TcpListener::bind("127.0.0.1:60606")?;
+    // TODO: Handle errors when binding ot the address.
+    let listener = TcpListener::bind("127.0.0.1:60606").await?;
 
-    // accept connections and process them serially
-    for stream in listener.incoming() {
-        // TODO: We might want to log or print something here
-        // if we get an Error type in `stream`.
-        // TODO: We also should handle any error coming back from
-        // `echo_stream`.
-        echo_stream(stream?)?;
+    loop {
+        // TODO: Handle errors when accepting requests.
+        let (socket, _) = listener.accept().await?;
+        tokio::spawn(async move {
+            // TODO: Handle error when processing socket.
+            echo_stream(socket).await.expect("There was a problem handling a socket");
+        });
     }
-    Ok(())
 }
 
-fn echo_stream(mut stream: TcpStream) -> Result<(), Error> {
-    println!("Handling a stream: {:?}", stream);
+async fn echo_stream(mut socket: TcpStream) -> io::Result<()> {
+    println!("Handling a stream: {:?}", socket);
     let mut buf = [0; BUFFER_SIZE];
     // TODO: Handle the error case here.
     loop {
-        let num_read_bytes = stream.read(&mut buf)?;
+        // Handle error when reading from socket.
+        let num_read_bytes = socket.read(&mut buf).await?;
         if num_read_bytes == 0 {
-            println!("Done handling stream {:?}", stream);
+            println!("Done handling stream {:?}", socket);
             return Ok(());
         }
         // TODO: Handle the error case here.
-        stream.write_all(&buf[0..num_read_bytes])?;
+        socket.write_all(&buf[0..num_read_bytes]).await?;
     }
 }


### PR DESCRIPTION
Rewrite the server implementation to use threads to allow for concurrent handling of connections.

This brings in Tokio to make the `main` and `echo_stream` function async and provide the ability to spawn threads to handle incoming connections.