### PR TITLE
Try `error-stack` and add logging

### DIFF
--- a/echo-server/Cargo.lock
+++ b/echo-server/Cargo.lock
@@ -24,7 +24,17 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 name = "echo-server"
 version = "0.1.0"
 dependencies = [
+ "error-stack",
  "tokio",
+]
+
+[[package]]
+name = "error-stack"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5975af488b218348f3f183862f88e8699a91a809f0ee2658fcafaa6239d6759e"
+dependencies = [
+ "rustc_version",
 ]
 
 [[package]]
@@ -108,6 +118,30 @@ checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "socket2"

--- a/echo-server/Cargo.lock
+++ b/echo-server/Cargo.lock
@@ -3,6 +3,26 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -24,8 +44,23 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 name = "echo-server"
 version = "0.1.0"
 dependencies = [
+ "env_logger",
  "error-stack",
+ "log",
  "tokio",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
 ]
 
 [[package]]
@@ -45,6 +80,12 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "libc"
@@ -120,6 +161,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+
+[[package]]
 name = "rustc_version"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,6 +220,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -221,6 +288,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/echo-server/Cargo.toml
+++ b/echo-server/Cargo.toml
@@ -6,4 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+error-stack = "0.1.1"
 tokio = { version = "1.20.1", features = ["rt-multi-thread", "macros", "net", "io-util"] }

--- a/echo-server/Cargo.toml
+++ b/echo-server/Cargo.toml
@@ -6,5 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+env_logger = "0.9.0"
 error-stack = "0.1.1"
+log = "0.4.17"
 tokio = { version = "1.20.1", features = ["rt-multi-thread", "macros", "net", "io-util"] }

--- a/echo-server/src/main.rs
+++ b/echo-server/src/main.rs
@@ -3,12 +3,44 @@
 #![warn(clippy::unwrap_used)]
 #![warn(clippy::expect_used)]
 
+use core::fmt;
 use std::io;
 
+use error_stack::{Context, Result, IntoReport, ResultExt};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 const BUFFER_SIZE: usize = 128;
+
+#[derive(Debug)]
+struct BindError;
+
+impl fmt::Display for BindError {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.write_str("Couldn't bind to the given address")
+    }
+}
+
+impl Context for BindError {}
+
+#[derive(Debug)]
+enum ServerError {
+    BindError(String),
+    IoError
+}
+
+impl fmt::Display for ServerError {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::BindError(address) 
+                => write!(fmt, "There was a problem binding to the server address {address}"),
+            Self::IoError 
+                => fmt.write_str("There was an I/O problem with the server")
+        }
+    }
+}
+
+impl Context for ServerError {}
 
 // Issues to deal with:
 // - Our error handling is fairly weak.
@@ -17,14 +49,22 @@ const BUFFER_SIZE: usize = 128;
 //   - We could specify the port number that way.
 
 #[tokio::main]
-async fn main() -> io::Result<()> {
+async fn main() -> Result<(), ServerError> {
     // TODO: Let the user set this port via the command line.
     // TODO: Handle errors when binding ot the address.
-    let listener = TcpListener::bind("127.0.0.1:60606").await?;
+    let server_address = "127.0.0.1:60606";
+    let listener 
+        = TcpListener::bind(server_address)
+            .await
+            .report()
+            .attach_printable_lazy(|| {
+                format!("Could not attach to address {server_address}.")
+            })
+            .change_context(ServerError::BindError(server_address.to_string()))?;
 
     loop {
         // TODO: Handle errors when accepting requests.
-        let (socket, _) = listener.accept().await?;
+        let (socket, _) = listener.accept().await.map_err(|_| ServerError::IoError)?;
         tokio::spawn(async move {
             // TODO: Handle error when processing socket.
             echo_stream(socket).await.expect("There was a problem handling a socket");

--- a/echo-server/src/main.rs
+++ b/echo-server/src/main.rs
@@ -32,7 +32,15 @@ fn parse_server_address(addr: &str) -> Result<SocketAddr, AddrParseError> {
         .attach_printable_lazy(|| {
             format!("Could not parse '{addr}' as a socket address")
         })
-        // .change_context(std::net::AddrParseError)
+}
+
+async fn bind_to_address(addr: SocketAddr) -> Result<TcpListener, io::Error> {
+    TcpListener::bind(addr)
+        .await
+        .report()
+        .attach_printable_lazy(|| {
+            format!("Could not attach to address {addr}.")
+        })
 }
 
 // Issues to deal with:
@@ -49,13 +57,10 @@ async fn main() -> Result<(), ServerError> {
     let server_address: SocketAddr 
         = parse_server_address(server_address)
           .change_context(ServerError)?;
+
     let listener 
-        = TcpListener::bind(server_address)
+        = bind_to_address(server_address)
             .await
-            .report()
-            .attach_printable_lazy(|| {
-                format!("Could not attach to address {server_address}.")
-            })
             .change_context(ServerError)?;
 
     loop {

--- a/echo-server/src/main.rs
+++ b/echo-server/src/main.rs
@@ -79,7 +79,7 @@ async fn accept_connection(listener: &TcpListener) -> Result<TcpStream, io::Erro
 //   - We could specify the port number that way.
 
 fn log_communication_error(err: &Report<ServerError>) {
-    error!("{err:?}");
+    error!("\n{err:?}");
 }
 
 #[tokio::main]
@@ -130,6 +130,10 @@ async fn echo_stream(mut socket: TcpStream) -> Result<(), SocketCommunicationErr
         if num_read_bytes == 0 {
             info!("Done handling stream {:?}", socket);
             return Ok(());
+            // The following lines force a communication error which might be useful
+            // for testing.
+            // return Err(Report::new(SocketCommunicationError::Read)
+            //             .attach_printable("We forced an error when the socket closed."));
         }
         socket
             .write_all(&buf[0..num_read_bytes])


### PR DESCRIPTION
This integrates the `error-stack` crate to improve the error handling (which was just a bunch of `unwrap()`s). We also needed to integrate logging, because we can't pass an error out of a future and back to the main thread when processing multiple sockets with multiple threads.